### PR TITLE
댓글 조회 및 신고 댓글 조회 api 구현, 사용자 정의 예외 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,21 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	// implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
 	compileOnly 'org.projectlombok:lombok'
+
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
+
 	annotationProcessor 'org.projectlombok:lombok'
+
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+	// testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/devgram/controller/CommentServiceController.java
+++ b/src/main/java/com/project/devgram/controller/CommentServiceController.java
@@ -2,10 +2,13 @@ package com.project.devgram.controller;
 
 import com.project.devgram.dto.CommentDto;
 import com.project.devgram.service.CommentService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,4 +25,21 @@ public class CommentServiceController {
     public CommentDto addComment(@RequestBody CommentDto commentInput) {
         return commentService.addComment(commentInput);
     }
+
+    /*
+     * 댓글 조회(보드)
+     */
+    @GetMapping
+    public List<CommentDto> getCommentList(@RequestParam Long boardSeq) {
+        return commentService.getCommentList(boardSeq);
+    }
+
+    /*
+     * 신고 댓글 조회(관리자)
+     */
+    @GetMapping("/accuse")
+    public List<CommentDto> getAccusedCommentList() {
+        return commentService.getAccusedCommentList();
+    }
 }
+

--- a/src/main/java/com/project/devgram/entity/Comment.java
+++ b/src/main/java/com/project/devgram/entity/Comment.java
@@ -2,6 +2,8 @@ package com.project.devgram.entity;
 
 import com.project.devgram.type.CommentStatus;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -29,5 +31,6 @@ public class Comment extends BaseEntity {
     private String createdBy;
     private String updatedBy;
 
+    @Enumerated(EnumType.STRING)
     private CommentStatus commentStatus;
 }

--- a/src/main/java/com/project/devgram/exception/DevGramException.java
+++ b/src/main/java/com/project/devgram/exception/DevGramException.java
@@ -1,0 +1,21 @@
+package com.project.devgram.exception;
+
+import com.project.devgram.exception.errorcode.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class DevGramException extends RuntimeException {
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public DevGramException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+}

--- a/src/main/java/com/project/devgram/exception/ErrorResponse.java
+++ b/src/main/java/com/project/devgram/exception/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.project.devgram.exception;
+
+import com.project.devgram.exception.errorcode.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ErrorResponse {
+    private ErrorCode errorCode;
+    private String errorMessage;
+}

--- a/src/main/java/com/project/devgram/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/devgram/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.project.devgram.exception;
+
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DevGramException.class)
+    public ErrorResponse devGramExceptionHandler(DevGramException e) {
+        return ErrorResponse.builder()
+            .errorCode(e.getErrorCode())
+            .errorMessage(e.getErrorMessage())
+            .build();
+    }
+}

--- a/src/main/java/com/project/devgram/exception/errorcode/CommentErrorCode.java
+++ b/src/main/java/com/project/devgram/exception/errorcode/CommentErrorCode.java
@@ -1,0 +1,13 @@
+package com.project.devgram.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum CommentErrorCode implements ErrorCode {
+    NOT_EXISTENT_COMMENT_FOR_BOARD("해당 게시글에 댓글이 존재하지 않습니다."),
+    NOT_EXISTENT_ACCUSED_COMMENT("신고된 댓글이 존재하지 않습니다.");
+
+    private final String description;
+}

--- a/src/main/java/com/project/devgram/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/project/devgram/exception/errorcode/ErrorCode.java
@@ -1,0 +1,6 @@
+package com.project.devgram.exception.errorcode;
+
+public interface ErrorCode {
+
+    String getDescription();
+}

--- a/src/main/java/com/project/devgram/repository/CommentRepository.java
+++ b/src/main/java/com/project/devgram/repository/CommentRepository.java
@@ -1,6 +1,5 @@
 package com.project.devgram.repository;
 
-import com.project.devgram.dto.CommentDto;
 import com.project.devgram.entity.Comment;
 import com.project.devgram.type.CommentStatus;
 import java.util.List;
@@ -8,7 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    Optional<List<CommentDto>> findByBoardSeqAndCommentStatusNot(Long boardSeq, CommentStatus commentStatus);
+    Optional<List<Comment>> findByBoardSeqAndCommentStatusNot(Long boardSeq, CommentStatus commentStatus);
 
-    Optional<List<CommentDto>> findByCommentStatus(CommentStatus commentStatus);
+    Optional<List<Comment>> findByCommentStatus(CommentStatus commentStatus);
 }

--- a/src/main/java/com/project/devgram/repository/CommentRepository.java
+++ b/src/main/java/com/project/devgram/repository/CommentRepository.java
@@ -1,8 +1,14 @@
 package com.project.devgram.repository;
 
+import com.project.devgram.dto.CommentDto;
 import com.project.devgram.entity.Comment;
+import com.project.devgram.type.CommentStatus;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Optional<List<CommentDto>> findByBoardSeqAndCommentStatusNot(Long boardSeq, CommentStatus commentStatus);
 
+    Optional<List<CommentDto>> findByCommentStatus(CommentStatus commentStatus);
 }

--- a/src/main/java/com/project/devgram/service/CommentService.java
+++ b/src/main/java/com/project/devgram/service/CommentService.java
@@ -1,10 +1,12 @@
 package com.project.devgram.service;
 
-import com.project.devgram.entity.Comment;
 import com.project.devgram.dto.CommentDto;
-import com.project.devgram.type.CommentStatus;
+import com.project.devgram.entity.Comment;
+import com.project.devgram.exception.DevGramException;
+import com.project.devgram.exception.errorcode.CommentErrorCode;
 import com.project.devgram.repository.CommentRepository;
-import java.time.LocalDateTime;
+import com.project.devgram.type.CommentStatus;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -27,5 +29,24 @@ public class CommentService {
             .build();
 
         return CommentDto.from(commentRepository.save(comment));
+    }
+
+    /*
+     * 댓글 조회(보드)
+     */
+    public List<CommentDto> getCommentList(Long boardSeq) {
+
+        return commentRepository.findByBoardSeqAndCommentStatusNot(boardSeq,
+                CommentStatus.DELETE)
+            .orElseThrow(() -> new DevGramException(
+                CommentErrorCode.NOT_EXISTENT_COMMENT_FOR_BOARD));
+    }
+
+    /*
+     * 신고 댓글 조회(관리자)
+     */
+    public List<CommentDto> getAccusedCommentList() {
+        return commentRepository.findByCommentStatus(CommentStatus.ACCUSE)
+            .orElseThrow(() -> new DevGramException(CommentErrorCode.NOT_EXISTENT_ACCUSED_COMMENT));
     }
 }

--- a/src/main/java/com/project/devgram/service/CommentService.java
+++ b/src/main/java/com/project/devgram/service/CommentService.java
@@ -6,6 +6,7 @@ import com.project.devgram.exception.DevGramException;
 import com.project.devgram.exception.errorcode.CommentErrorCode;
 import com.project.devgram.repository.CommentRepository;
 import com.project.devgram.type.CommentStatus;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,17 +37,33 @@ public class CommentService {
      */
     public List<CommentDto> getCommentList(Long boardSeq) {
 
-        return commentRepository.findByBoardSeqAndCommentStatusNot(boardSeq,
+        List<Comment> commentList = commentRepository.findByBoardSeqAndCommentStatusNot(boardSeq,
                 CommentStatus.DELETE)
             .orElseThrow(() -> new DevGramException(
                 CommentErrorCode.NOT_EXISTENT_COMMENT_FOR_BOARD));
+
+        ArrayList<CommentDto> commentDtoList = new ArrayList<>();
+
+        for (Comment comment: commentList) {
+            commentDtoList.add(CommentDto.from(comment));
+        }
+
+        return commentDtoList;
     }
 
     /*
      * 신고 댓글 조회(관리자)
      */
     public List<CommentDto> getAccusedCommentList() {
-        return commentRepository.findByCommentStatus(CommentStatus.ACCUSE)
+        List<Comment> commentList = commentRepository.findByCommentStatus(CommentStatus.ACCUSE)
             .orElseThrow(() -> new DevGramException(CommentErrorCode.NOT_EXISTENT_ACCUSED_COMMENT));
+
+        ArrayList<CommentDto> commentDtoList = new ArrayList<>();
+
+        for (Comment comment: commentList) {
+            commentDtoList.add(CommentDto.from(comment));
+        }
+
+        return commentDtoList;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,25 @@
+spring:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
 
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;
+    username: sa
+
+#  sql:
+#    init:
+#      mode: embedded
+#      data-locations: classpath:dataH2.sql
 
 

--- a/src/test/java/com/project/devgram/service/CommentServiceTest.java
+++ b/src/test/java/com/project/devgram/service/CommentServiceTest.java
@@ -1,13 +1,21 @@
 package com.project.devgram.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 import com.project.devgram.dto.CommentDto;
 import com.project.devgram.entity.Comment;
+import com.project.devgram.exception.DevGramException;
+import com.project.devgram.exception.errorcode.CommentErrorCode;
 import com.project.devgram.repository.CommentRepository;
 import com.project.devgram.type.CommentStatus;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,5 +66,83 @@ class CommentServiceTest {
         assertEquals(result.getParentCommentSeq(), comment.getParentCommentSeq());
         assertEquals(result.getCreatedAt(), comment.getCreatedAt());
         assertEquals(result.getCreatedBy(), comment.getCreatedBy());
+    }
+
+    @DisplayName("댓글 조회 - 성공")
+    @Test
+    void getCommentList_success() {
+        // given
+        List<Comment> commentList = new ArrayList<>();
+
+        for (long i = 0; i < 11; i++) {
+            commentList.add(Comment.builder()
+                .commentSeq(i)
+                .boardSeq(1L)
+                .content(i + "content")
+                .commentStatus(CommentStatus.POST)
+                .build());
+        }
+
+        given(commentRepository.findByBoardSeqAndCommentStatusNot(1L, CommentStatus.DELETE)).willReturn(
+            Optional.of(commentList));
+
+        // when
+        List<CommentDto> commentDtoList = commentService.getCommentList(1L);
+
+        // then
+        assertEquals(commentDtoList.size(), 11);
+    }
+
+    @DisplayName("댓글 조회 - 실패 - 해당 게시글에 댓글 존재하지 않음")
+    @Test
+    void getCommentList_fail() {
+        // given
+
+        given(commentRepository.findByBoardSeqAndCommentStatusNot(1L, CommentStatus.DELETE)).willReturn(Optional.empty());
+
+        // when
+        DevGramException devGramException = assertThrows(DevGramException.class, () -> commentService.getCommentList(1L));
+
+        // then
+        assertEquals(devGramException.getErrorCode(), CommentErrorCode.NOT_EXISTENT_COMMENT_FOR_BOARD);
+    }
+
+    @DisplayName("신고 댓글 조회 - 성공")
+    @Test
+    void getAccuseCommentList_success() {
+        // given
+        List<Comment> commentList = new ArrayList<>();
+
+        for (long i = 0; i < 11; i++) {
+            commentList.add(Comment.builder()
+                .commentSeq(i)
+                .boardSeq(1L)
+                .content(i + "content")
+                .commentStatus(CommentStatus.ACCUSE)
+                .build());
+        }
+
+        given(commentRepository.findByCommentStatus(CommentStatus.ACCUSE)).willReturn(
+            Optional.of(commentList));
+
+        // when
+        List<CommentDto> commentDtoList = commentService.getAccusedCommentList();
+
+        // then
+        assertEquals(commentDtoList.size(), 11);
+    }
+
+    @DisplayName("신고 댓글 조회 - 실패 - 신고 댓글이 존재하지 않음")
+    @Test
+    void getAccuseCommentList_fail() {
+        // given
+
+        given(commentRepository.findByCommentStatus(CommentStatus.ACCUSE)).willReturn(Optional.empty());
+
+        // when
+        DevGramException devGramException = assertThrows(DevGramException.class, () -> commentService.getAccusedCommentList());
+
+        // then
+        assertEquals(devGramException.getErrorCode(), CommentErrorCode.NOT_EXISTENT_ACCUSED_COMMENT);
     }
 }


### PR DESCRIPTION
### 변경
- 댓글 조회 api 구현 및 테스트 코드(service) 작성
- 신고 댓글 조회 api 구현 및 테스트 코드(service) 작성

### 추후 작업
- 댓글 신고 api 및 테스트 코드 작성

### 논의 사항
- 우선 제 임의대로 사용자 정의 예외, 핸들러 구현해두었습니다. 예외 처리에 대해 논의가 필요할 것 같습니다.