### PR TITLE
태그 목록 조회 및 특정 태그 삭제 api 구현, DB 민감 정보 삭제

### DIFF
--- a/src/main/java/com/project/devgram/controller/TagController.java
+++ b/src/main/java/com/project/devgram/controller/TagController.java
@@ -1,0 +1,35 @@
+package com.project.devgram.controller;
+
+import com.project.devgram.dto.TagDto;
+import com.project.devgram.service.TagService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/tags")
+public class TagController {
+
+    private final TagService tagService;
+
+    /*
+     * 전체 태그 목록 조회
+     */
+    @GetMapping
+    public List<TagDto> getTagList() {
+        return tagService.getTagList();
+    }
+
+    /*
+     * 특정 태그 삭제
+     */
+    @DeleteMapping
+    public String deleteTag(@RequestParam Long tagSeq) {
+        return tagService.deleteTag(tagSeq);
+    }
+}

--- a/src/main/java/com/project/devgram/dto/TagDto.java
+++ b/src/main/java/com/project/devgram/dto/TagDto.java
@@ -1,0 +1,29 @@
+package com.project.devgram.dto;
+
+import com.project.devgram.entity.Tag;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class TagDto {
+    private Long tagSeq;
+
+    private String name;
+
+    private Long useCount;
+
+    public static TagDto from(Tag tag) {
+        return new TagDto(tag.getTagSeq(), tag.getName(), tag.getUseCount());
+    }
+
+    public static List<TagDto> fromList(List<Tag> tagList) {
+        List<TagDto> tagDtoList = new ArrayList<>();
+
+        for (Tag tag: tagList) {
+            tagDtoList.add(from(tag));
+        }
+
+        return tagDtoList;
+    }
+}

--- a/src/main/java/com/project/devgram/entity/Tag.java
+++ b/src/main/java/com/project/devgram/entity/Tag.java
@@ -1,0 +1,27 @@
+package com.project.devgram.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long tagSeq;
+
+    private String name;
+
+    private Long useCount;
+}

--- a/src/main/java/com/project/devgram/exception/errorcode/TagErrorCode.java
+++ b/src/main/java/com/project/devgram/exception/errorcode/TagErrorCode.java
@@ -1,0 +1,12 @@
+package com.project.devgram.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum TagErrorCode implements ErrorCode {
+    NOT_EXISTENT_TAG("등록된 태그가 없습니다.");
+
+    private final String description;
+}

--- a/src/main/java/com/project/devgram/repository/TagRepository.java
+++ b/src/main/java/com/project/devgram/repository/TagRepository.java
@@ -1,0 +1,8 @@
+package com.project.devgram.repository;
+
+import com.project.devgram.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+}

--- a/src/main/java/com/project/devgram/service/TagService.java
+++ b/src/main/java/com/project/devgram/service/TagService.java
@@ -1,0 +1,43 @@
+package com.project.devgram.service;
+
+import com.project.devgram.dto.TagDto;
+import com.project.devgram.entity.Tag;
+import com.project.devgram.exception.DevGramException;
+import com.project.devgram.exception.errorcode.TagErrorCode;
+import com.project.devgram.repository.TagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    /*
+     * 태그 전체 목록 조회
+     */
+    public List<TagDto> getTagList() {
+        List<Tag> tagList = tagRepository.findAll();
+
+        if (tagList.isEmpty()) {
+            throw new DevGramException(TagErrorCode.NOT_EXISTENT_TAG);
+        }
+
+        return TagDto.fromList(tagList);
+    }
+
+    /*
+     * 특정 태그 삭제
+     */
+    public String deleteTag(Long tagSeq) {
+
+        tagRepository.delete(
+            tagRepository.findById(tagSeq)
+                .orElseThrow(() -> new DevGramException(TagErrorCode.NOT_EXISTENT_TAG))
+        );
+
+        return "태그 삭제 완료";
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,10 +1,10 @@
 spring:
 
   datasource:
-    url: jdbc:mysql://localhost:3306/devgram
+    url: jdbc:mysql://localhost:3306/****
     driver-class-name: com.mysql.cj.jdbc.Driver
-    username: root
-    password: 1
+    username: '****'
+    password: '****'
 
   jpa:
     generate-ddl: true

--- a/src/test/java/com/project/devgram/service/TagServiceTest.java
+++ b/src/test/java/com/project/devgram/service/TagServiceTest.java
@@ -1,0 +1,106 @@
+package com.project.devgram.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.project.devgram.dto.TagDto;
+import com.project.devgram.entity.Tag;
+import com.project.devgram.exception.DevGramException;
+import com.project.devgram.exception.errorcode.TagErrorCode;
+import com.project.devgram.repository.TagRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TagServiceTest {
+
+    @InjectMocks
+    private TagService tagService;
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @Test
+    @DisplayName("태그 목록 조회 - 성공")
+    void getTagList_success() {
+        // given
+        List<Tag> tagList = new ArrayList<>();
+
+        for (int i = 0; i < 10; i++) {
+            tagList.add(Tag.builder()
+                .name("name" + i)
+                .useCount((long) i)
+                .build());
+        }
+
+        given(tagRepository.findAll()).willReturn(tagList);
+
+        // when
+        List<TagDto> result = tagService.getTagList();
+
+        // then
+        assertEquals(result.size(), tagList.size());
+    }
+
+    @Test
+    @DisplayName("태그 목록 조회 - 실패 - 태그 존재 X")
+    void getTagList_fail_notExistent() {
+        // given
+        List<Tag> tagList = new ArrayList<>();
+
+        given(tagRepository.findAll()).willReturn(tagList);
+
+        // when
+        DevGramException devGramException = assertThrows(DevGramException.class,
+            () -> tagService.getTagList());
+
+        // then
+        assertEquals(devGramException.getErrorCode(), TagErrorCode.NOT_EXISTENT_TAG);
+    }
+
+    @Test
+    @DisplayName("특정 태그 삭제 - 성공")
+    void deleteTag_success() {
+        // given
+        Tag tag = Tag.builder()
+            .tagSeq(1L)
+            .name("name")
+            .useCount(1L)
+            .build();
+
+        given(tagRepository.findById(1L)).willReturn(Optional.of(tag));
+
+        // when
+        String result = tagService.deleteTag(1L);
+
+        // then
+        verify(tagRepository).delete(tag);
+        assertEquals(result, "태그 삭제 완료");
+    }
+
+    @Test
+    @DisplayName("특정 태그 삭제 - 실패 - 태그 존재 X")
+    void deleteTag_fail_notExistent() {
+        // given
+        given(tagRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when
+        DevGramException devGramException = assertThrows(DevGramException.class,
+            () -> tagService.deleteTag(anyLong()));
+
+        // then
+
+        assertEquals(devGramException.getErrorCode(), TagErrorCode.NOT_EXISTENT_TAG);
+    }
+
+}


### PR DESCRIPTION
### 변경 사항
- 태그 목록 조회 api, 특정 태그 삭제 api 구현 및 테스트 코드 작성
- **데이터베이스, ID, Password가 그대로 노출되는 건 좋지 않다고 생각하여, 임의로 삭제해두었습니다.**
  - **의견 주시면, 머지할 때 포함 또는 제외 하겠습니다.**
  
### 추후 작업
- table 연관 관계 mapping 
- 태그 자동 완성 기능

