### PR TITLE
full text index를 통한 자동완성 기능 구현

### DIFF
--- a/src/main/java/com/project/devgram/controller/TagController.java
+++ b/src/main/java/com/project/devgram/controller/TagController.java
@@ -37,7 +37,7 @@ public class TagController {
      * 태그 자동 완성
      */
     @GetMapping("/autocomplete")
-    public List<TagDto> autocompleteTag(@RequestParam String name) {
-        return tagService.autoCompleteTag(name);
+    public List<TagDto> autocompleteTag(@RequestParam("searchTag") String searchTag) {
+        return tagService.autoCompleteTag(searchTag);
     }
 }

--- a/src/main/java/com/project/devgram/dto/TagDto.java
+++ b/src/main/java/com/project/devgram/dto/TagDto.java
@@ -4,9 +4,15 @@ import com.project.devgram.entity.Tag;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 
+@Getter
+@Builder
 @AllArgsConstructor
+@RequiredArgsConstructor
 public class TagDto {
     private Long tagSeq;
 

--- a/src/main/java/com/project/devgram/repository/TagRepository.java
+++ b/src/main/java/com/project/devgram/repository/TagRepository.java
@@ -5,10 +5,17 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
     Optional<Tag> findByNameIgnoreCase(String name);
 
-    Page<Tag> findByNameContainsIgnoreCase(String name, Pageable pageable);
+    // like문 자동완성
+    // Page<Tag> findByNameContainsIgnoreCase(String name, Pageable pageable);
+
+    // full text index 자동완성, 사용 횟수 높은 순 정렬, 5개 반환(pageable)
+    @Query(value = "SELECT * FROM tag where MATCH(name) AGAINST (:searchTag IN BOOLEAN MODE) ORDER BY use_count desc", nativeQuery = true)
+    Page<Tag> searchByFti(@Param("searchTag") String searchTag, Pageable pageable);
 }

--- a/src/main/java/com/project/devgram/service/TagService.java
+++ b/src/main/java/com/project/devgram/service/TagService.java
@@ -28,7 +28,7 @@ public class TagService {
             return;
         }
 
-        for (String tagName: tagNames) {
+        for (String tagName : tagNames) {
             Optional<Tag> optionalTag = tagRepository.findByNameIgnoreCase(tagName);
 
             if (optionalTag.isEmpty()) {
@@ -76,10 +76,10 @@ public class TagService {
     /*
      * 태그 자동 완성
      */
-    public List<TagDto> autoCompleteTag(String name) {
+    public List<TagDto> autoCompleteTag(String searchTag) {
         Pageable limit = PageRequest.of(0, 5);
 
-        Page<Tag> tagList = tagRepository.findByNameContainsIgnoreCase(name, limit);
+        Page<Tag> tagList = tagRepository.searchByFti(searchTag, limit);
 
         if (tagList.isEmpty()) {
             throw new DevGramException(TagErrorCode.NOT_CORRESPOND_TAG);


### PR DESCRIPTION
### 변경 사항
- like %s% -> full text index를 통한 자동완성 기능
- 사용 횟수 높은 순 정렬, 5개 반환
- 필요한 DB 설정(**팀장님, 배포 시에 문제가 없을 지 확인 부탁드립니다!**)
  1. my.cnf(Mac) 또는 my.ini(windows) 파일 설정: [mysqld] 아래에 ngram_token_size=1 작성
  2. full text index 추가: CREATE FULLTEXT INDEX fti_tag_name on tag(name) with parser ngram;

### 추후 작업
- 대댓글 기능 확인 및 수정